### PR TITLE
wol compilation fix.

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -984,7 +984,7 @@ dhcpv6/stamp-h1:
 	@touch dhcpv6/stamp-h1
 
 wol/stamp-h1:
-	ac_cv_func_malloc_0_nonnull=yes cd $(TOP)/wol && $(CONFIGURE) --host=mips --prefix=$(INSTALLDIR)/wol CC=mipsel-uclibc-gcc STRIP=mipsel-uclibc-strip AR=mipsel-uclibc-ar LD=mipsel-uclibc-ld NM=mipsel-uclibc-nm RANLIB=mipsel-uclibc-ranlib
+	cd $(TOP)/wol && jm_cv_func_working_malloc=yes $(CONFIGURE) --host=mips --prefix=$(INSTALLDIR)/wol CC=mipsel-uclibc-gcc STRIP=mipsel-uclibc-strip AR=mipsel-uclibc-ar LD=mipsel-uclibc-ld NM=mipsel-uclibc-nm RANLIB=mipsel-uclibc-ranlib
 	touch wol/stamp-h1
 
 wol: wol/stamp-h1

--- a/release/src/router/wol/configure.ac
+++ b/release/src/router/wol/configure.ac
@@ -95,6 +95,12 @@ else dnl BSD
 	fi
 fi
 
+dnl config.h.in defines
+AC_DEFINE([HAVE_STRUCT_ETHER_ADDR], 0, [struct ether_addr])
+AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_ETHER_ADDR_OCTET], 0, [struct ether_addr.ether_addr_octet])
+AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_OCTET], 0, [struct ether_addr.octet])
+AC_DEFINE([HAVE_ETHER_HOSTTON], 0, [ether_hostton])
+
 dnl check struct members
 if test "$ac_cv_type_struct_ether_addr" = "yes"; then
 	AC_CHECK_MEMBER([struct ether_addr.octet], , , [$ether_includes])
@@ -240,12 +246,6 @@ dnl *** Unable to find python.
 dnl *** Because of that, you won't be able to run certain tests via 'make check'.])
 dnl fi
 
-
-dnl config.h.in defines
-AC_DEFINE([HAVE_STRUCT_ETHER_ADDR], 0, [struct ether_addr])
-AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_ETHER_ADDR_OCTET], 0, [struct ether_addr.ether_addr_octet])
-AC_DEFINE([HAVE_STRUCT_ETHER_ADDR_OCTET], 0, [struct ether_addr.octet])
-AC_DEFINE([HAVE_ETHER_HOSTTON], 0, [ether_hostton])
 
 
 dnl full featured warnings


### PR DESCRIPTION
This commit fixes the wol compilation. 
There are three issues fixed:
1. The variable in makefile to suppress the usage of rpl_malloc is jm_cv_func_working_malloc, not ac_cv_func_working_malloc. The latter is used when the autotools macro for rpl_malloc test is used. But wol has its own test based on former variable. (Can check this in aclocal.m4)
1. In the rule to run configure for wol, we need to cd to the wol directory first and then set the variable and run configure otherwise the variable value that is set by us doesn't stick.
2. The config.h.in macros in configure.ac corresponding to the ether_addr struct should be kept before its corresponding tests, otherwise the config.h.in has the default values after the tests and override them even if the tests are successful, leading to wol trying to use its own inbuild ether_addr definition and failing with a redefinition error.
