### PR TITLE
Mount scripts

### DIFF
--- a/README-merlin.txt
+++ b/README-merlin.txt
@@ -65,7 +65,7 @@ certain events occur:
 - Firewall is started (rules are applied): /jffs/scripts/firewall-start.
 - Right after jffs is mounted, before any of the services get started:
   /jffs/scripts/init-start
-- Just before a partition is mounted: /jffs/scripts/pre-mount
+- Just before a partition is mounted: /jffs/scripts/pre-mount (Be careful with this script. This is run in a blocking call and will block the mounting of the said partition till its execution is complete. This is done so that it can be used for things like running e2fsck on the partition before mounting)
 - Just after a partition is mounted: /jffs/scripts/post-mount
 
 Those scripts must all be located under /jffs/scripts/ (so JFFS support 

--- a/README-merlin.txt
+++ b/README-merlin.txt
@@ -65,7 +65,7 @@ certain events occur:
 - Firewall is started (rules are applied): /jffs/scripts/firewall-start.
 - Right after jffs is mounted, before any of the services get started:
   /jffs/scripts/init-start
-- Just before a partition is mounted: /jffs/scripts/pre-mount (Be careful with this script. This is run in a blocking call and will block the mounting of the said partition till its execution is complete. This is done so that it can be used for things like running e2fsck on the partition before mounting)
+- Just before a partition is mounted: /jffs/scripts/pre-mount (Be careful with this script. This is run in a blocking call and will block the mounting of the partition  for which it is invoked till its execution is complete. This is done so that it can be used for things like running e2fsck on the partition before mounting. This script is also passed the device path being mounted as an argument which can be used in the script using $1)
 - Just after a partition is mounted: /jffs/scripts/post-mount
 
 Those scripts must all be located under /jffs/scripts/ (so JFFS support 

--- a/README-merlin.txt
+++ b/README-merlin.txt
@@ -65,6 +65,8 @@ certain events occur:
 - Firewall is started (rules are applied): /jffs/scripts/firewall-start.
 - Right after jffs is mounted, before any of the services get started:
   /jffs/scripts/init-start
+- Just before a partition is mounted: /jffs/scripts/pre-mount
+- Just after a partition is mounted: /jffs/scripts/post-mount
 
 Those scripts must all be located under /jffs/scripts/ (so JFFS support 
 must be enabled first).

--- a/release/src/router/rc/common.c
+++ b/release/src/router/rc/common.c
@@ -1430,3 +1430,15 @@ void run_custom_script(char *name)
 }
 // Merlin's additions - End
 
+void run_custom_script_blocking(char *name, char *args)
+{
+	char script[120];
+
+	sprintf(script, "/jffs/scripts/%s", name);
+
+        if(f_exists(script)) {
+                _dprintf("Script: running %s\n", script);
+                eval(script, args);
+        }
+
+}

--- a/release/src/router/rc/usb.c
+++ b/release/src/router/rc/usb.c
@@ -769,6 +769,8 @@ int mount_partition(char *dev_name, int host_num, char *dsc_name, char *pt_name,
 	if(!is_valid_hostname(the_label))
 		memset(the_label, 0, 128);
 
+    run_custom_script("pre-mount");
+
 	if (f_exists("/etc/fstab")) {
 		if (strcmp(type, "swap") == 0) {
 			_eval(swp_argv, NULL, 0, NULL);
@@ -860,6 +862,7 @@ done:
 		if (nvram_get_int("usb_automount"))
 			run_nvscript("script_usbmount", mountpoint, 3);
 
+        run_custom_script("post-mount");
 	}
 	return (ret == MOUNT_VAL_RONLY || ret == MOUNT_VAL_RW);
 }

--- a/release/src/router/rc/usb.c
+++ b/release/src/router/rc/usb.c
@@ -769,7 +769,7 @@ int mount_partition(char *dev_name, int host_num, char *dsc_name, char *pt_name,
 	if(!is_valid_hostname(the_label))
 		memset(the_label, 0, 128);
 
-    run_custom_script("pre-mount");
+    run_custom_script_blocking("pre-mount", dev_name);
 
 	if (f_exists("/etc/fstab")) {
 		if (strcmp(type, "swap") == 0) {
@@ -862,7 +862,7 @@ done:
 		if (nvram_get_int("usb_automount"))
 			run_nvscript("script_usbmount", mountpoint, 3);
 
-        run_custom_script("post-mount");
+        run_custom_script_blocking("post-mount", mountpoint);
 	}
 	return (ret == MOUNT_VAL_RONLY || ret == MOUNT_VAL_RW);
 }


### PR DESCRIPTION
Added scripts that are run before a partition is mounted and after a partition is mounted.

pre-mount is useful for many things, the most common use being running e2fsck on a file system automatically before it is mounted

post-mount is useful for things like that can be autorun when a partition is mounted. e.g. running rc.unslung or another process that can start your optware related program installations on boot up. Other scripts like services-start are not useful for this because they are not really in sync with when a partition is exactly mounted. e.g. services-start some times run even before the system actually mounts a partition and makes it available.

I've tested these scripts with the above mentioned scenarios on my system and they are working pretty well in starting up optware and running fsck when needed.
